### PR TITLE
Fix parameter order in LiveCameraView init calls

### DIFF
--- a/TreeTop/Views/LiveCameraView.swift
+++ b/TreeTop/Views/LiveCameraView.swift
@@ -129,7 +129,7 @@ struct CameraPreview: UIViewRepresentable {
 #Preview {
     LiveCameraView(
         project: Project(name: "Preview Project", date: Date(), folderName: "PreviewFolder"),
-        shouldGoToExistingProjects: .constant(false),
-        subfolder: "Diagonal1/Originals"
+        subfolder: "Diagonal1/Originals",
+        shouldGoToExistingProjects: .constant(false)
     )
 }

--- a/TreeTop/Views/NewProjectView.swift
+++ b/TreeTop/Views/NewProjectView.swift
@@ -39,7 +39,7 @@ struct NewProjectView: View {
         }
         .padding(.top, 50)
         .navigationDestination(item: $createdProject) {
-            project in LiveCameraView(project: project, shouldGoToExistingProjects: $shouldGoToExistingProjects, subfolder: "Diagonal1/Originals")
+            project in LiveCameraView(project: project, subfolder: "Diagonal1/Originals", shouldGoToExistingProjects: $shouldGoToExistingProjects)
                 .onAppear{
                     print("navigating to camera")
                 }

--- a/TreeTop/Views/ProjectContentsView.swift
+++ b/TreeTop/Views/ProjectContentsView.swift
@@ -37,10 +37,10 @@ struct ProjectContentsView: View {
         }
         .navigationTitle("Project Contents")
         .sheet(isPresented: $showDiagonal1Camera) {
-            LiveCameraView(project: project, shouldGoToExistingProjects: .constant(false), subfolder: "Diagonal1/Originals")
+            LiveCameraView(project: project, subfolder: "Diagonal1/Originals", shouldGoToExistingProjects: .constant(false))
         }
         .sheet(isPresented: $showDiagonal2Camera) {
-            LiveCameraView(project: project, shouldGoToExistingProjects: .constant(false), subfolder: "Diagonal2/Originals")
+            LiveCameraView(project: project, subfolder: "Diagonal2/Originals", shouldGoToExistingProjects: .constant(false))
         }
     }
 


### PR DESCRIPTION
## Summary
- pass parameters to `LiveCameraView` in the required order
- update preview code to match

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebb515040832cbab64e6e1e1e7113