### PR TITLE
Improve mask generator model loading

### DIFF
--- a/TreeTop/Managers/UIImageExtensions.swift
+++ b/TreeTop/Managers/UIImageExtensions.swift
@@ -16,7 +16,7 @@ extension UIImage {
         let status = CVPixelBufferCreate(kCFAllocatorDefault,
                                          Int(size.width),
                                          Int(size.height),
-                                         kCVPixelFormatType_32ARGB,
+                                         kCVPixelFormatType_32BGRA,
                                          attrs,
                                          &pixelBuffer)
         guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
@@ -29,7 +29,7 @@ extension UIImage {
                                 bitsPerComponent: 8,
                                 bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
                                 space: CGColorSpaceCreateDeviceRGB(),
-                                bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue)
+                                bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue)
         if let cgImage = cgImage {
             context?.draw(cgImage, in: CGRect(origin: .zero, size: size))
         }


### PR DESCRIPTION
## Summary
- handle runtime compilation of `.mlpackage` when compiled model isn't present
- debug logs for model loading issues
- create pixel buffers with BGRA format to match CoreML expectations
- infer mask width/height from output array

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687419f0363c832c9539ec2c1244cd50