### PR TITLE
Optimize image handling and UI performance

### DIFF
--- a/TreeTop/Managers/ProjectManager.swift
+++ b/TreeTop/Managers/ProjectManager.swift
@@ -145,7 +145,9 @@ class ProjectManager {
         let fileName = "image_\(dateFormatter.string(from: Date())).jpg"
         let fileURL = folderURL.appendingPathComponent(fileName)
         
-        guard let imageData = image.jpegData(compressionQuality: 0.9) else {
+        let optimizedImage = image.downscaled(maxDimension: 1800) ?? image
+
+        guard let imageData = optimizedImage.jpegData(compressionQuality: 0.7) else {
             return false
         }
         
@@ -211,8 +213,10 @@ class ProjectManager {
         
                     // Saving center reference image
         
-        // Save full-size image
-        guard let imageData = image.jpegData(compressionQuality: 0.9) else {
+        // Save optimized full-size image
+        let optimizedImage = image.downscaled(maxDimension: 2000) ?? image
+
+        guard let imageData = optimizedImage.jpegData(compressionQuality: 0.75) else {
             // Failed to convert image to JPEG data
             return false
         }

--- a/TreeTop/Managers/UIImageExtensions.swift
+++ b/TreeTop/Managers/UIImageExtensions.swift
@@ -3,6 +3,20 @@ import CoreVideo
 import Accelerate
 
 extension UIImage {
+    /// Downscale image while preserving aspect ratio to avoid memory bloat
+    /// - Parameter maxDimension: Maximum width or height allowed
+    /// - Returns: A resized image that fits within the max dimension
+    func downscaled(maxDimension: CGFloat = 1800) -> UIImage? {
+        guard size.width > 0 && size.height > 0 else { return nil }
+
+        let largestSide = max(size.width, size.height)
+        guard largestSide > maxDimension else { return self }
+
+        let scale = maxDimension / largestSide
+        let targetSize = CGSize(width: size.width * scale, height: size.height * scale)
+        return resized(to: targetSize)
+    }
+
     // Optimized resizing with better memory management
     func resized(to size: CGSize) -> UIImage? {
         // Safety check for zero or negative dimensions

--- a/TreeTop/Views/LiveCameraView.swift
+++ b/TreeTop/Views/LiveCameraView.swift
@@ -207,7 +207,8 @@ struct LiveCameraView: View {
             cameraManager.stopSession()
         }
         .onChange(of: cameraManager.capturedImage) {
-            capturedImages.append(contentsOf: cameraManager.capturedImage)
+            let optimized = cameraManager.capturedImage.compactMap { $0.downscaled(maxDimension: 1800) ?? $0 }
+            capturedImages.append(contentsOf: optimized)
             isPreviewingPhoto = true
             cameraManager.capturedImage = []
         }
@@ -263,7 +264,9 @@ struct LiveCameraView: View {
                 let filename = "image_\(dateFormatter.string(from: Date()))_\(String(format: "%02d", index)).jpg"
                 let fileURL = saveToURL.appendingPathComponent(filename)
 
-                if let data = image.jpegData(compressionQuality: 1.0) {
+                let optimizedImage = image.downscaled(maxDimension: 1800) ?? image
+
+                if let data = optimizedImage.jpegData(compressionQuality: 0.7) {
                     try data.write(to: fileURL)
                     savedImageURLs.append(fileURL)
                     // Image saved successfully

--- a/TreeTop/Views/MainMenuView.swift
+++ b/TreeTop/Views/MainMenuView.swift
@@ -14,8 +14,8 @@ struct MainMenuView: View {
     var body: some View {
         NavigationStack(path: $path) {
             ZStack {
-                // Animated forest background
-                AnimatedForestBackground()
+                // Adaptive background respects performance settings to reduce lag on older devices
+                AdaptiveForestBackground()
                     .allowsHitTesting(false) // Prevent background from intercepting touches
                 
                 VStack(spacing: 32) {


### PR DESCRIPTION
## Summary
- downscale captured photos before saving to reduce file size and memory pressure
- compress saved JPEGs and center reference images to shrink storage and speed disk writes
- hook main menu background into performance settings to avoid heavy animations on slower devices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222e21f560832c809dd1c0cf7b8a9f)